### PR TITLE
PEP08 and rename "Publish" to "Artist"

### DIFF
--- a/pyblish_lite/app.css
+++ b/pyblish_lite/app.css
@@ -115,3 +115,8 @@ QPushButton:hover {
 #ClosingPlaceholder {
 	background: rgba(0, 0, 0, 50);
 }
+
+#Artist #Comment, #Artist #CommentLabel {
+	font-family: Open Sans;
+	font-size: 9pt;
+}

--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -45,20 +45,20 @@ class Window(QtWidgets.QDialog):
 
         header = QtWidgets.QWidget()
 
-        publish_tab = QtWidgets.QRadioButton()
+        artist_tab = QtWidgets.QRadioButton()
         overview_tab = QtWidgets.QRadioButton()
         terminal_tab = QtWidgets.QRadioButton()
         spacer = QtWidgets.QWidget()
 
         layout = QtWidgets.QHBoxLayout(header)
-        layout.addWidget(publish_tab, 0)
+        layout.addWidget(artist_tab, 0)
         layout.addWidget(overview_tab, 0)
         layout.addWidget(terminal_tab, 0)
         layout.addWidget(spacer, 1)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        """Publish
+        """Artist Page
          ___________________
         |                  |
         | o ------------   |
@@ -70,32 +70,32 @@ class Window(QtWidgets.QDialog):
 
         """
 
-        publish = QtWidgets.QWidget()
+        artist = QtWidgets.QWidget()
 
-        publish_view = view.Item()
+        artist_view = view.Item()
 
-        item_delegate = delegate.Publish()
-        publish_view.setItemDelegate(item_delegate)
+        item_delegate = delegate.Artist()
+        artist_view.setItemDelegate(item_delegate)
 
-        verticalLine = QtWidgets.QFrame()
+        vertical_line = QtWidgets.QFrame()
 
-        verticalLine.setFrameStyle(QtWidgets.QFrame.HLine)
-        verticalLine.setSizePolicy(
+        vertical_line.setFrameStyle(QtWidgets.QFrame.HLine)
+        vertical_line.setSizePolicy(
             QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
 
         comment_label = QtWidgets.QLabel("Comment")
         comment = QtWidgets.QTextEdit()
         self.comment = comment
 
-        layout = QtWidgets.QVBoxLayout(publish)
-        layout.addWidget(publish_view, 4)
-        layout.addWidget(verticalLine)
+        layout = QtWidgets.QVBoxLayout(artist)
+        layout.addWidget(artist_view, 4)
+        layout.addWidget(vertical_line)
         layout.addWidget(comment_label)
         layout.addWidget(self.comment, 1)
         layout.setContentsMargins(5, 5, 5, 5)
         layout.setSpacing(0)
 
-        """Overview
+        """Overview Page
          ___________________
         |                  |
         | o ----- o----    |
@@ -149,7 +149,7 @@ class Window(QtWidgets.QDialog):
         body = QtWidgets.QWidget()
         layout = QtWidgets.QHBoxLayout(body)
         layout.setContentsMargins(5, 5, 5, 0)
-        layout.addWidget(publish)
+        layout.addWidget(artist)
         layout.addWidget(overview)
         layout.addWidget(terminal)
 
@@ -197,7 +197,7 @@ class Window(QtWidgets.QDialog):
         plugin_model = model.Plugin()
         terminal_model = model.Terminal()
 
-        publish_view.setModel(instance_model)
+        artist_view.setModel(instance_model)
         left_view.setModel(instance_model)
         right_view.setModel(plugin_model)
         terminal_view.setModel(terminal_model)
@@ -225,7 +225,7 @@ class Window(QtWidgets.QDialog):
             "Info": info,
 
             # Tabs
-            "Publish": publish,
+            "Publish": artist,
             "Overview": overview,
             "Terminal": terminal,
 
@@ -244,7 +244,7 @@ class Window(QtWidgets.QDialog):
         # Enable CSS on plain QWidget objects
         for widget in (header,
                        body,
-                       publish,
+                       artist,
                        comment,
                        overview,
                        terminal,
@@ -257,7 +257,7 @@ class Window(QtWidgets.QDialog):
 
         self.data = {
             "views": {
-                "publish": publish_view,
+                "artist": artist_view,
                 "left": left_view,
                 "right": right_view,
                 "terminal": terminal_view,
@@ -268,7 +268,7 @@ class Window(QtWidgets.QDialog):
                 "terminal": terminal_model,
             },
             "tabs": {
-                "publish": publish,
+                "artist": artist,
                 "overview": overview,
                 "terminal": terminal,
             },
@@ -281,7 +281,7 @@ class Window(QtWidgets.QDialog):
                 # These are internal caches of the data
                 # visualised by the model. The model then
                 # modified these objects as-is, such as their
-                # "active" attribute or "publish" data.
+                # "active" attribute or "artist" data.
                 "context": list(),
                 "plugins": list(),
 
@@ -290,7 +290,7 @@ class Window(QtWidgets.QDialog):
                 "is_closing": False,
                 "close_requested": False,
 
-                # Transient state used during publishing
+                # Transient state used during artisting
                 # This is used to track whether or not to continue
                 # processing when, for example, validation has failed.
                 "processing": {
@@ -301,7 +301,7 @@ class Window(QtWidgets.QDialog):
         }
 
         # Defaults
-        self.on_tab_changed("publish")
+        self.on_tab_changed("artist")
 
         """Signals
          ________     ________
@@ -314,8 +314,8 @@ class Window(QtWidgets.QDialog):
         """
 
         # NOTE: Listeners to this signal are run in the main thread
-        publish_tab.released.connect(
-            lambda: self.on_tab_changed("publish"))
+        artist_tab.released.connect(
+            lambda: self.on_tab_changed("artist"))
         overview_tab.released.connect(
             lambda: self.on_tab_changed("overview"))
         terminal_tab.released.connect(
@@ -324,7 +324,7 @@ class Window(QtWidgets.QDialog):
         self.about_to_process.connect(self.on_about_to_process,
                                       QtCore.Qt.DirectConnection)
 
-        publish_view.toggled.connect(self.on_delegate_toggled)
+        artist_view.toggled.connect(self.on_delegate_toggled)
         left_view.toggled.connect(self.on_delegate_toggled)
         right_view.toggled.connect(self.on_delegate_toggled)
         reset.clicked.connect(self.on_reset_clicked)

--- a/pyblish_lite/control.py
+++ b/pyblish_lite/control.py
@@ -59,13 +59,17 @@ class Window(QtWidgets.QDialog):
         layout.setSpacing(0)
 
         """Artist Page
-         ___________________
+         __________________
         |                  |
-        | o ------------   |
-        | o ------------   |
-        | o ------------   |
+        | | ------------   |
+        | | -----          |
+        |                  |
+        | | --------       |
+        | | -------        |
+        |                  |
         |------------------|
-        | comment          |
+        |                  |
+        | comment >        |
         |__________________|
 
         """
@@ -74,26 +78,20 @@ class Window(QtWidgets.QDialog):
 
         artist_view = view.Item()
 
-        item_delegate = delegate.Artist()
-        artist_view.setItemDelegate(item_delegate)
+        artist_delegate = delegate.Artist()
+        artist_view.setItemDelegate(artist_delegate)
 
-        vertical_line = QtWidgets.QFrame()
-
-        vertical_line.setFrameStyle(QtWidgets.QFrame.HLine)
-        vertical_line.setSizePolicy(
-            QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Expanding)
-
-        comment_label = QtWidgets.QLabel("Comment")
         comment = QtWidgets.QTextEdit()
-        self.comment = comment
+        comment_label = QtWidgets.QLabel(
+            "Enter optional comment here..", comment)
+        comment_label.move(6, 6)
+        comment_label.hide()
 
         layout = QtWidgets.QVBoxLayout(artist)
         layout.addWidget(artist_view, 4)
-        layout.addWidget(vertical_line)
-        layout.addWidget(comment_label)
-        layout.addWidget(self.comment, 1)
-        layout.setContentsMargins(5, 5, 5, 5)
-        layout.setSpacing(0)
+        layout.addWidget(comment, 1)
+        layout.setContentsMargins(0, 0, 0, 5)
+        layout.setSpacing(5)
 
         """Overview Page
          ___________________
@@ -225,7 +223,7 @@ class Window(QtWidgets.QDialog):
             "Info": info,
 
             # Tabs
-            "Publish": artist,
+            "Artist": artist,
             "Overview": overview,
             "Terminal": terminal,
 
@@ -236,6 +234,8 @@ class Window(QtWidgets.QDialog):
 
             # Misc
             "ClosingPlaceholder": closing_placeholder,
+            "Comment": comment,
+            "CommentLabel": comment_label
         }
 
         for name, widget in names.items():
@@ -352,9 +352,13 @@ class Window(QtWidgets.QDialog):
         self.data["state"]["is_running"] = False
 
     def on_comment_entered(self):
-        comment = self.comment.toPlainText()
+        text_edit = self.findChild(QtWidgets.QTextEdit, "Comment")
+        comment = text_edit.toPlainText()
         context = self.data["state"]["context"]
         context.data['comment'] = comment
+
+        label = self.findChild(QtWidgets.QLabel, "CommentLabel")
+        label.setVisible(not comment)
 
     def on_delegate_toggled(self, index, state=None):
         """An item is requesting to be toggled"""

--- a/pyblish_lite/delegate.py
+++ b/pyblish_lite/delegate.py
@@ -15,6 +15,8 @@ colors = {
 
 
 class Item(QtWidgets.QStyledItemDelegate):
+    """Generic delegate for model items"""
+
     def __init__(self):
         super(Item, self).__init__()
 
@@ -103,9 +105,12 @@ class Item(QtWidgets.QStyledItemDelegate):
     def sizeHint(self, option, index):
         return QtCore.QSize(option.rect.width(), 20)
 
-class Publish(QtWidgets.QStyledItemDelegate):
+
+class Artist(QtWidgets.QStyledItemDelegate):
+    """Delegate used on Artist page"""
+
     def __init__(self):
-        super(Publish, self).__init__()
+        super(Artist, self).__init__()
 
         font = QtGui.QFont()
         font.setFamily("Open Sans")
@@ -162,8 +167,8 @@ class Publish(QtWidgets.QStyledItemDelegate):
 
         family = index.data(model.Family)
         family = metrics.elidedText(family,
-                                   QtCore.Qt.ElideRight,
-                                   rect.width())
+                                    QtCore.Qt.ElideRight,
+                                    rect.width())
 
         font_color = colors["idle"]
         if not index.data(model.IsChecked):
@@ -214,6 +219,8 @@ class Publish(QtWidgets.QStyledItemDelegate):
 
 
 class Terminal(QtWidgets.QStyledItemDelegate):
+    """Delegate used exclusively for the Terminal"""
+
     def __init__(self):
         super(Terminal, self).__init__()
 

--- a/pyblish_lite/delegate.py
+++ b/pyblish_lite/delegate.py
@@ -70,7 +70,7 @@ class Item(QtWidgets.QStyledItemDelegate):
             font_color = colors["inactive"]
 
         hover = QtGui.QPainterPath()
-        hover.addRect(option.rect.adjusted(0, 0, -1, -1))
+        hover.addRect(QtCore.QRectF(option.rect).adjusted(0, 0, -1, -1))
 
         # Maintain reference to state, so we can restore it once we're done
         painter.save()
@@ -175,7 +175,7 @@ class Artist(QtWidgets.QStyledItemDelegate):
             font_color = colors["inactive"]
 
         hover = QtGui.QPainterPath()
-        hover.addRect(option.rect.adjusted(0, 0, -1, -1))
+        hover.addRect(QtCore.QRectF(option.rect).adjusted(0, 0, -1, -1))
 
         # Maintan reference to state, so we can restore it once we're done
         painter.save()
@@ -185,12 +185,12 @@ class Artist(QtWidgets.QStyledItemDelegate):
         painter.setPen(QtGui.QPen(font_color))
         painter.drawText(rect, label)
 
-        rect1 = QtCore.QRectF(option.rect.adjusted(17, 18, 0, -2))
+        rect = QtCore.QRectF(option.rect.adjusted(17, 18, 0, -2))
 
         # Draw family
         painter.setFont(self.font_family)
         painter.setPen(QtGui.QPen(colors["inactive"]))
-        painter.drawText(rect1, family)
+        painter.drawText(rect, family)
 
         # Draw checkbox
         pen = QtGui.QPen(check_color, 1)
@@ -260,8 +260,12 @@ class Terminal(QtWidgets.QStyledItemDelegate):
         if index.data(model.Type) == "error":
             font_color = colors["warning"]
 
+        rect = QtCore.QRectF(option.rect)
+        rect.setWidth(rect.height())
+        rect.adjust(0, 0, -1, -1)
+
         hover = QtGui.QPainterPath()
-        hover.addRect(option.rect.adjusted(0, 0, -1, -1))
+        hover.addRect(rect)
 
         # Maintan reference to state, so we can restore it once we're done
         painter.save()


### PR DESCRIPTION
A few tweaks I found a bit misleading at first.

The word "publish" is quite reserved for publishing I think, should we refer to this new tab as "Artist View"?

Some minor style concerns, the vertical line makes sense, to separate between the list and comment area, but I'm not sure it's the best of looks. I'll have a look at an alternative and post here? Are you working on this at the moment?